### PR TITLE
Load proxy contract from ABI and document deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ This file is intended for AI agents (e.g. GitHub Copilot, ChatGPT / Codex) that 
    - Suggesting improvements for UX, Discoverability, Testing
    - Ensuring `sdk.actions.ready()` is used correctly, and other best practices
    - Maintaining the `contracts/` directory and keeping `index.html` in sync with the deployed contract address
+   - The prize pool contract is currently deployed at `0xA82ad49C77160D09F49c6f5fDf35d3000685b624` with proxy `0xDB30fa8787C71Cf725E5b377130Df5fBEB3BbF5E`
+   - `index.html` loads its ABI and address from `abi/TicTacVatoPrizePool.json`; update this file if redeploying
+   - The public site is hosted at `https://vato.sqmu.io`
 
 3. **Prompt the user with context-based questions**, **only referencing the docs** and not quoting from them verbatim. Example prompts:
    - “Should we create `farcaster.json` now with placeholders, or generate it later once the GH Pages URL is known?”

--- a/README.md
+++ b/README.md
@@ -22,12 +22,20 @@ A minimalist Farcaster Mini App that lets users play Tic Tac Toe ("Tic Tac Vato"
 
 ---
 
-## Prerequisites
+## Deployment
 
+- Live app: [https://vato.sqmu.io](https://vato.sqmu.io)
+- Prize pool contract (proxy): `0xDB30fa8787C71Cf725E5b377130Df5fBEB3BbF5E`
+- Implementation: `0xA82ad49C77160D09F49c6f5fDf35d3000685b624`
+- ABI: `abi/TicTacVatoPrizePool.json`
+
+`index.html` fetches the ABI and contract address from the JSON file above. Update it if the contract redeploys or the domain changes.
+
+---
+
+## Prerequisites
 - You'll later need to **self-host** on a domain (e.g. GitHub Pages)
-- Replace placeholders:
-- `index.html` includes a `CONTRACT_ADDRESS` constant that must be updated once the contract is deployed
-  - Your GitHub Pages URL for manifest & domain identity
+- If you fork this project, replace the domain and update `abi/TicTacVatoPrizePool.json` with your own deployment details.
 - Enable **Developer Mode** in Farcaster web to preview the app:
   1. Sign into Farcaster
   2. Visit [Farcaster Dev Tools](https://farcaster.xyz/~/settings/developer-tools)

--- a/index.html
+++ b/index.html
@@ -106,14 +106,7 @@
         }
       }
 
-      const CONTRACT_ADDRESS = '0xYourContractAddress';
-      const ABI = [
-        'function prizePool() view returns (uint256)',
-        'function currentFee() view returns (uint256)',
-        'function getLeaderboard() view returns (address[3], uint256[3])',
-        'function play() payable',
-        'function getConfig() view returns (uint256 minPool, uint256 maxPool, uint16 feeBps)'
-      ];
+      const { address: CONTRACT_ADDRESS, abi: ABI } = await fetch('abi/TicTacVatoPrizePool.json').then(r => r.json());
       const ethersProvider = new ethers.BrowserProvider(provider);
       const signer = await ethersProvider.getSigner();
       const contract = new ethers.Contract(CONTRACT_ADDRESS, ABI, signer);


### PR DESCRIPTION
## Summary
- load prize pool ABI and address from `abi/TicTacVatoPrizePool.json`
- document live deployment at https://vato.sqmu.io with proxy and implementation addresses
- update agent instructions with deployed contract and hosting details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a30bb594832a8b3b44e3ab12fe25