### PR TITLE
refactor: switch to miniapp manifest

### DIFF
--- a/.well-known/farcaster.json
+++ b/.well-known/farcaster.json
@@ -1,18 +1,21 @@
 {
-  "frame": {
-    "name": "Tic Tac Vato",
+  "miniapp": {
     "version": "1",
+    "name": "Tic Tac Vato",
     "iconUrl": "https://vato.sqmu.io/assets/icon.jpg",
     "homeUrl": "https://vato.sqmu.io",
     "imageUrl": "https://vato.sqmu.io/assets/og.jpg",
+    "buttonTitle": "Play Now",
     "splashImageUrl": "https://vato.sqmu.io/assets/og.jpg",
     "splashBackgroundColor": "#FF6B00",
     "webhookUrl": "https://vato.sqmu.io/api/webhook",
-    "subtitle": "Outwit the Code Cholo",
-    "description": "Tic Tac Vato, How Good Are You?",
-    "primaryCategory": "games"
+    "requiredChains": ["eip155:42161"],
+    "requiredCapabilities": [
+      "wallet.getEthereumProvider",
+      "actions.ready"
+    ]
   },
-"accountAssociation": {
+  "accountAssociation": {
     "header": "eyJmaWQiOjExMTUxNTIsInR5cGUiOiJjdXN0b2R5Iiwia2V5IjoiMHhCQzdiQjBlMDAyOTNERDJFNDMxNTIyNTc2MzYzMDREM0NFNDQyNTcyIn0",
     "payload": "eyJkb21haW4iOiJ2YXRvLnNxbXUuaW8ifQ",
     "signature": "MHg4ZWMzYWNmMjNmYjRkMDEyODNlMGUwNzA5ZDVhZWVlYzZlNGY5MmM1YzIwMzUyNzQwZTJhODM2NGUzYmJjMGEwNTQ3ODU4MTYzNjQ3MjE1NzRkNGRlMzI2MzY3NzI4OTJkMzNkMzAzNWI4NmI5YjRhMTI3Yzg1YmU2ZjNiMDhjMDFj"


### PR DESCRIPTION
## Summary
- migrate Farcaster manifest from `frame` to `miniapp`
- add required chain and capability declarations
- keep existing `accountAssociation`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ff53bd04832aa8869b5f3f708e76