### PR TITLE
Wrap startup logic in try/finally

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,8 +97,9 @@
     } from 'https://esm.sh/viem@2.9.32';
 
     (async () => {
-      // EIP-1193 provider from Mini App
-      const provider = await sdk.wallet.getEthereumProvider();
+      try {
+        // EIP-1193 provider from Mini App
+        const provider = await sdk.wallet.getEthereumProvider();
 
       // UI elements
       const els = {
@@ -302,11 +303,11 @@
       // Initial load + periodic refresh
       await refreshUI();
       setInterval(refreshUI, 8000);
-    } finally {
-      // Signal to host that rendering has completed
-      try { await sdk.actions.ready(); } catch {}
-    }
-  })();
+      } finally {
+        // Signal to host that rendering has completed
+        try { await sdk.actions.ready(); } catch {}
+      }
+    })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap initialization code in a `try` block
- call `sdk.actions.ready()` in a guarded `finally`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b84a464832a8cfc2ce47801fbf9