### PR TITLE
Call sdk.actions.ready early in mini app

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,9 @@
 
     (async () => {
       try {
+        // Signal readiness as soon as minimal DOM is rendered
+        sdk.actions.ready().catch(() => {});
+
         // EIP-1193 provider from Mini App
         const provider = await sdk.wallet.getEthereumProvider();
 


### PR DESCRIPTION
## Summary
- Trigger `sdk.actions.ready()` immediately after the DOM is rendered to signal readiness sooner.
- Retain a fallback `finally` block that also calls `sdk.actions.ready()` in case of errors.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20d548c0c832aa7ebe7d8471e7cf0